### PR TITLE
Running yarn before running gatsby cli

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,8 @@ if [ -n "$GATSBY_PROJECT_PATH" ]; then
   cd "$GATSBY_PROJECT_PATH" || exit
 fi
 
+sh -c "yarn"
+
 sh -c "gatsby $*"
 ACTUAL_EXIT="$?"
 


### PR DESCRIPTION
Issue: Cannot run github action in my github CI/CD due to missing node_modules directory.

Cause: yarn install or npm install isn't run prior to running gatsby cli on github CI/CD.
Fix: Ensuring to run yarn before running gatsby cli.
Note that we could do this manually as well as a different step, but it likely belongs here as having node_modules being installed is a dependency for this to work.
Test: Tested github action w/ the fix on my fork.