### PR TITLE
Upgrade node to 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:12-slim
 
 LABEL version="1.0.0"
 LABEL "repository"="http://github.com/jzweifel/gatsby-cli-github-action"


### PR DESCRIPTION
Currently we have an issue with node 10:

```sh
gatsby-core-utils@2.0.0: The engine "node" is incompatible with this module. Expected version ">=12.13.0". Got "10.24.0"
```