### PR TITLE
upgrade node to v14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:14-slim
 
 LABEL version="1.0.0"
 LABEL "repository"="http://github.com/jzweifel/gatsby-cli-github-action"


### PR DESCRIPTION
Fixes the error (#11):

`error gatsby-core-utils@3.7.0: The engine "node" is incompatible with this module. Expected version ">=14.15.0". Got "12.22.10"`